### PR TITLE
Reemplace property justify-content value

### DIFF
--- a/src/card/_card.scss
+++ b/src/card/_card.scss
@@ -46,7 +46,7 @@
   color: $card-text-color;
   display: block;
   display: flex;
-  justify-content: stretch;
+  justify-content: space-between;
   line-height: normal;
   padding: $card-vertical-padding $card-horizontal-padding;
   perspective-origin: $card-title-perspective-origin-x $card-title-perspective-origin-y;


### PR DESCRIPTION
The justify-content property accept only values `flex-start` | `flex-end` | `center` | `space-between` | `space-around.` 
if the idea is to "stretch" the size of the container the best option would: `space-between`.

Properties documentation: https://drafts.csswg.org/css-flexbox-1/#justify-content-property
